### PR TITLE
docs: clarify archived neovim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # nvim
-nvim configuration file
+
+A personal collection of configuration files for [Neovim](https://neovim.io/). It uses the
+[vim-plug](https://github.com/junegunn/vim-plug) plugin manager and includes plugins for
+language support, git integration, file browsing and a custom user interface.
+
+## Old configuration
+
+This was my very first Neovim setup when I started exploring the editor. I have since moved
+on to a different configuration and **no longer use this one**. Feel free to browse the files
+or use them as a starting point for your own setup.
+
+## Archived
+
+This repository is kept for historical reference and is now archived. No further development
+or maintenance will be performed. Issues and pull requests are unlikely to receive a
+response.
 
 ## Installation instructions
 
-    1. Clone this repository in ~/.config
-    2. run nvim
-    3. run :PlugInstall (in nvim)
+1. Clone this repository into `~/.config`.
+2. Run `nvim`.
+3. Run `:PlugInstall` inside Neovim to install plugins.
+
+To manage this configuration alongside other dotfiles, consider using a tool like
+[GNU Stow](https://www.gnu.org/software/stow/).


### PR DESCRIPTION
## Summary
- expand README with description of Neovim config
- note repository is archived and kept only for historical reference
- suggest GNU Stow for dotfile management

## Testing
- `markdownlint README.md` *(fails: command not found)*
- `npm install -g markdownlint-cli` *(fails: 403 Forbidden)*
- `npx markdownlint README.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a5499e1483219f3ab2cbe02e8313